### PR TITLE
Update to go 1.23

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,11 +36,11 @@
               dprint
               typos
               go-task
-              go_1_22
+              go_1_23
             ];
           };
 
-        packages.gwurl = pkgs.buildGo122Module {
+        packages.gwurl = pkgs.buildGo123Module {
           pname = "gwurl";
           version = updaterVersion;
           src = pkgs.lib.cleanSource self;

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kachick/gwurl
 
-go 1.22.1
+go 1.23.1
 
 require golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028
 


### PR DESCRIPTION
- **Bump go version to 1.23 in flake**
- **`go get "go@$(go version | grep -oP '(?<=go)\d\S+')"`**
